### PR TITLE
Avoids "Call to undefined method Illuminate\Auth\GenericUser::toArray…

### DIFF
--- a/zray/zray.php
+++ b/zray/zray.php
@@ -124,9 +124,11 @@ class Laravel {
 			//guest
 			$storage['userInformation'][]=array('Name'=>'Guest','Additional Info'=>'Not Logged-in');
 			return;
+		} else {
+			$storage['userInformation'][]=array('Name'=>$user->id);
 		}
 		
-		$storage['userInformation'][]=$user->toArray();
+
 	}
 	protected function loadSymfonyRoutePanel(&$storage){
 		$name = \Route::currentRouteName();


### PR DESCRIPTION
…()" which effectively breaks ZRay and possibly user's application

It does not seem that Illuminate\Auth\GenericUser ever had a method toArray(), so I re-arranged your code a bit.